### PR TITLE
Implement weekly activity progress on dashboard

### DIFF
--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -10,7 +10,14 @@ interface UserStats {
   level: number;
   dueCount: number;
   streakFreezeCount: number;
-  weeklyActivity: unknown;
+  weeklyActivity: Record<
+    string,
+    {
+      questionsReviewed: number;
+      xpEarned: number;
+      accuracy: number;
+    }
+  >;
 }
 
 interface BuyFreezeResponse {


### PR DESCRIPTION
### Motivation
- Surface real per-day weekly activity in the dashboard so the Weekly Progress widget reflects actual review counts and XP rather than a hardcoded demo.
- Make the `weeklyActivity` shape explicit in the stats hook to avoid `unknown` usage and enable safe UI consumption.

### Description
- Added explicit typing for `weeklyActivity` in `src/hooks/useStats.ts` as `Record<string, { questionsReviewed: number; xpEarned: number; accuracy: number }>`.
- Reworked the weekly widget in `src/app/_components/DashboardClient.tsx` to accept `activity` and compute the current week date keys with `useMemo` so the UI maps `YYYY-MM-DD` keys to weekday slots.
- The widget now highlights today, shows checkmarks for days with activity, and exposes simple tooltips with review and XP summary for each day.
- Imported `useMemo` and passed `stats?.weeklyActivity` into `WeeklyProgress` so the component is driven by real backend data.

### Testing
- Started the dev server with `npm run dev` and Next compiled successfully (Google Fonts fetch warned but fallback font was used). 
- Rendered the dashboard and captured a Playwright screenshot of the updated widget (`artifacts/dashboard.png`) to validate the UI change.
- No unit/integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696be8ced5808326a89e3ca8a305e213)